### PR TITLE
Configure excerpt size via SiteSettings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+plugins:
+  topic_excerpt_length:
+    default: 150
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,9 +3,11 @@
 # version: 0.2
 # authors: Angus McLeod, Johani
 
+enabled_site_setting :topic_excerpt_length
+
 after_initialize do
   add_to_class :post, :excerpt_for_topic do
-      Post.excerpt(cooked, 50, strip_links: true)
+      Post.excerpt(cooked, SiteSetting.topic_excerpt_length, strip_links: true)
   end
   add_to_serializer(:listable_topic, :include_excerpt?) { true }
 end


### PR DESCRIPTION
Allow the SiteSettings to configure the size of the excerpt length for different clients.